### PR TITLE
Clean up warnings

### DIFF
--- a/PSEMU/Bits.h
+++ b/PSEMU/Bits.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#define ANY_BIT_SET(value, bit) (((value) & (bit)) != 0)
+#define ALL_BITS_SET(value, bit) (((value) & (bit)) == bit)

--- a/PSEMU/Bus.cpp
+++ b/PSEMU/Bus.cpp
@@ -458,6 +458,8 @@ void Bus::do_dma_block(Port port) {
         case Step::Decrement:
             return -4;
         }
+
+        return 0;
     }();
 
     auto addr = channel.get_base();

--- a/PSEMU/CPU.cpp
+++ b/PSEMU/CPU.cpp
@@ -436,8 +436,8 @@ void CPU::op_bxx()
 
     auto instruction = instr.instruction;
 
-    auto is_bgez = (instruction >> 16) & 1;
-    auto is_link = (instruction >> 20) & 1 != 0;
+    auto is_bgez = ANY_BIT_SET(instruction, 1 << 16);
+    auto is_link = ANY_BIT_SET(instruction, 1 << 20);
 
     auto v = (int32_t)regs[s];
 
@@ -447,7 +447,7 @@ void CPU::op_bxx()
     // If the test is "greater than or equal to zero" we need to
     // negate the comparison above ("a >= 0" <=> "!(a < 0)"). The
     // xor takes care of that.
-    test = test ^ is_bgez;
+    test = test ^ (is_bgez ? 1 : 0);
 
     if (test != 0) {
         if (is_link){

--- a/PSEMU/CPU.h
+++ b/PSEMU/CPU.h
@@ -3,6 +3,7 @@
 #include <tuple>
 #include <cstring>
 #include "Instruction.h"
+#include "Bits.h"
 
 enum Exception {
     SysCall = 0x8,
@@ -111,7 +112,7 @@ public:
 	}
 
 	void store32(uint32_t addr, uint32_t value) {
-		if (sr & 0x10000 != 0) {
+		if (ANY_BIT_SET(sr, 0x10000)) {
 			// Cache is isolated, ignore write
 			std::cout << "[CPU] INFO: Ignore load while cache is isolated\n";
 			return;
@@ -120,7 +121,7 @@ public:
 	}
 
 	void store16(uint32_t addr, uint32_t value) {
-		if (sr & 0x10000 != 0) {
+		if (ANY_BIT_SET(sr, 0x10000)) {
 			// Cache is isolated, ignore write
 			std::cout << "[CPU] INFO: Ignore load while cache is isolated\n";
 			return;
@@ -129,7 +130,7 @@ public:
 	}
 
 	void store8(uint32_t addr, uint32_t value) {
-		if (sr & 0x10000 != 0) {
+		if (ANY_BIT_SET(sr, 0x10000)) {
 			// Cache is isolated, ignore write
 			std::cout << "[CPU] INFO: Ignore load while cache is isolated\n";
 			return;

--- a/PSEMU/DMA.cpp
+++ b/PSEMU/DMA.cpp
@@ -1,4 +1,5 @@
 #include "DMA.h"
+#include "Bits.h"
 
 bool DMA::irq() {
 	auto channel_irq = channel_irq_flags & channel_irq_en;
@@ -23,11 +24,11 @@ void DMA::set_interrupt(uint32_t value) {
 	// Unknown what bits [5:0] do
 	irq_dummy = (uint8_t)(value & 0x3f);
 
-	force_irq = (value >> 15) & 1 != 0;
+	force_irq = ANY_BIT_SET(value, 1 << 15);
 
 	channel_irq_en = (uint8_t)((value >> 16) & 0x7f);
 
-	irq_en = (value >> 23) & 1 != 0;
+	irq_en = ANY_BIT_SET(value, 1 << 23);
 
 	// Writing 1 to a flag resets it
 	auto ack = (uint8_t)((value >> 24) & 0x3f);
@@ -51,25 +52,17 @@ uint32_t DMAChannel::control() {
 }
 
 void DMAChannel::set_control(uint32_t val) {
-	switch (val & 1 != 0) {
-	case true: 
+	if (ANY_BIT_SET(val, 1))
 		direction = Direction::FromRam;
-		break;
-	case false:
+	else
 		direction = Direction::ToRam;
-		break;
-	};
 
-	switch ((val >> 1) & 1 != 0) {
-	case true:
+	if (ANY_BIT_SET(val, 2))
 		step = Step::Decrement;
-		break;
-	case false:
+	else
 		step = Step::Increment;
-		break;
-	};
 
-	chop = (val >> 8) & 1 != 0;
+	chop = ANY_BIT_SET(val, 1 << 8);
 
 	switch ((val >> 9) & 3) {
 	case 0:
@@ -92,8 +85,8 @@ void DMAChannel::set_control(uint32_t val) {
 	chop_dma_sz = (uint8_t)((val >> 16) & 7);
 	chop_cpu_sz = (uint8_t)((val >> 20) & 7);
 
-	enable = (val >> 24) & 1 != 0;
-	trigger = (val >> 28) & 1 != 0;
+	enable = ANY_BIT_SET(val, 1 << 24);
+	trigger = ANY_BIT_SET(val, 1 << 28);
 
 	dummy = (uint8_t)((val >> 29) & 3);
 }
@@ -140,6 +133,8 @@ std::optional<uint32_t> DMAChannel::transfer_size() {
 	case Sync::LinkedList:
 		return std::nullopt;
 	}
+
+	return 0;
 }
 
 void DMAChannel::done() {

--- a/PSEMU/PSEMU.vcxproj
+++ b/PSEMU/PSEMU.vcxproj
@@ -106,6 +106,7 @@
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -143,6 +144,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Bios.h" />
+    <ClInclude Include="Bits.h" />
     <ClInclude Include="Bus.h" />
     <ClInclude Include="CPU.h" />
     <ClInclude Include="DMA.h" />

--- a/PSEMU/PSEMU.vcxproj.filters
+++ b/PSEMU/PSEMU.vcxproj.filters
@@ -31,6 +31,9 @@
     <Filter Include="Source Files\Bus\DMA">
       <UniqueIdentifier>{3dcc3f34-d96f-4c55-abea-df2abfcfccee}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\Utility">
+      <UniqueIdentifier>{e9115966-a38b-49ef-a9de-79906ff510f6}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="PSEMU.cpp">
@@ -78,6 +81,9 @@
     </ClInclude>
     <ClInclude Include="DMA.h">
       <Filter>Source Files\Bus\DMA</Filter>
+    </ClInclude>
+    <ClInclude Include="Bits.h">
+      <Filter>Source Files\Utility</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/PSEMU/RAM.cpp
+++ b/PSEMU/RAM.cpp
@@ -28,7 +28,7 @@ void RAM::store32(uint32_t offset, uint32_t value) {
 }
 
 void RAM::store16(uint32_t offset, uint16_t val) {
-    uint8_t b0 = val;
+    uint8_t b0 = static_cast<uint8_t>(val);
     uint8_t b1 = (val >> 8);
 
     ram[offset + 0] = b0;


### PR DESCRIPTION
This PR:

- Eliminates all build warnings. Some of these were in fact indicating actual errors in the code logic.
- Enables "Treat warnings as errors" so that future code will have to be "clean" to compile. 🙂 